### PR TITLE
Fix alpha conversion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC = gcc
 CFLAGS = -Wall -g
 LDFLAGS = -lm
-SRC = config.c parser.c reducer.c io.c main.c hash-table/hash_table.c
+SRC = common.c config.c parser.c reducer.c io.c main.c hash-table/hash_table.c
 OBJDIR = obj
 OBJS = $(patsubst %.c, $(OBJDIR)/%.o, $(SRC))
 EXECUTABLE = lc

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CC = gcc
 CFLAGS = -Wall -g
+LDFLAGS = -lm
 SRC = config.c parser.c reducer.c io.c main.c hash-table/hash_table.c
 OBJDIR = obj
 OBJS = $(patsubst %.c, $(OBJDIR)/%.o, $(SRC))
@@ -8,7 +9,7 @@ EXECUTABLE = lc
 all: $(EXECUTABLE)
 
 $(EXECUTABLE): $(OBJS)
-	$(CC) $(CFLAGS) $^ -o $@
+	$(CC) $(CFLAGS) $^ $(LDFLAGS) -o $@
 
 $(OBJDIR)/%.o: %.c | $(OBJDIR)
 	$(CC) $(CFLAGS) -c $< -o $@

--- a/common.c
+++ b/common.c
@@ -1,0 +1,90 @@
+#include "common.h"
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <stdlib.h>
+
+static int n = 1;
+
+static bool verbose_mode = false;
+
+void set_verbose(bool verbose) {
+  verbose_mode = verbose;
+}
+
+void print_ast_verbose(AstNode *n) {
+  if (verbose_mode == false) {
+    return;
+  }
+  char *lambda_ast = ast_to_string(n);
+  printf("%s\n", lambda_ast);
+}
+
+void print_verbose(const char *format, ...) {
+  if (verbose_mode == false) {
+    return;
+  }
+  printf("\n");
+  va_list args;
+  va_start(args, format);
+  vprintf(format, args);
+  va_end(args);
+}
+
+void append_to_buffer(char **buffer, size_t *buffer_size, size_t *length, const char *str) {
+    size_t str_len = strlen(str);
+    while (*length + str_len + 1 >= *buffer_size) {
+        *buffer_size *= 2;
+        *buffer = realloc(*buffer, *buffer_size);
+    }
+    strcpy(*buffer + *length, str);
+    *length += str_len;
+}
+
+void append_ast_to_buffer(char **buffer, size_t *buffer_size, size_t *length, AstNode *node) {
+    if (node == NULL) {
+        return;
+    }
+
+    switch (node->type) {
+        case LAMBDA_EXPR:
+            append_to_buffer(buffer, buffer_size, length, "(@");
+            append_to_buffer(buffer, buffer_size, length, node->node.lambda_expr->parameter);
+            append_to_buffer(buffer, buffer_size, length, ".");
+            append_ast_to_buffer(buffer, buffer_size, length, node->node.lambda_expr->body);
+            append_to_buffer(buffer, buffer_size, length, ") ");
+            break;
+
+        case APPLICATION:
+            append_to_buffer(buffer, buffer_size, length, "(");
+            append_ast_to_buffer(buffer, buffer_size, length, node->node.application->function);
+            append_ast_to_buffer(buffer, buffer_size, length, node->node.application->argument);
+            append_to_buffer(buffer, buffer_size, length, ") ");
+            break;
+
+        case VAR:
+            append_to_buffer(buffer, buffer_size, length, "(");
+            append_to_buffer(buffer, buffer_size, length, node->node.variable->name);
+            append_to_buffer(buffer, buffer_size, length, ") ");
+            break;
+
+        case DEFINITION:
+            append_to_buffer(buffer, buffer_size, length, "(");
+            append_to_buffer(buffer, buffer_size, length, node->node.variable->name);
+            append_to_buffer(buffer, buffer_size, length, ") ");
+            break;
+
+        default:
+            append_to_buffer(buffer, buffer_size, length, "(UNKNOWN) ");
+    }
+}
+
+char *ast_to_string(AstNode *node) {
+    size_t buffer_size = 1024;
+    char *buffer = malloc(buffer_size);
+    buffer[0] = '\0';
+    size_t length = 0;
+    append_ast_to_buffer(&buffer, &buffer_size, &length, node);
+    return buffer;
+}

--- a/common.h
+++ b/common.h
@@ -1,5 +1,6 @@
 #ifndef COMMON_H
 #define COMMON_H
+#include <stdbool.h>
 
 #define HANDLE_NULL(ptr)                                                       \
   do {                                                                         \
@@ -55,5 +56,13 @@ struct AstNode {
   AstNodeType type;
   AstNodeUnion node;
 };
+
+void set_verbose(bool verbose);
+
+void print_ast_verbose(AstNode *n);
+
+void print_verbose(const char *format, ...);
+
+char *ast_to_string(AstNode *node);
 
 #endif

--- a/expr.lambda
+++ b/expr.lambda
@@ -1,6 +1,5 @@
-def a = @x.x 
+def a = @x.x
 
 def b = @y.y
 
-(a b)
-
+((@x.x b) c)

--- a/hash-table/hash_table.c
+++ b/hash-table/hash_table.c
@@ -28,6 +28,12 @@ void insert(HashTable *hashTable, const char *key, struct AstNode *value) {
   }
 }
 
+bool table_exists(HashTable *hashTable, const char *key) {
+  unsigned int index = hash(key);
+  HashNode *node = hashTable->table[index];
+  return node != NULL;
+}
+
 AstNode *search(HashTable *hashTable, const char *key) {
   if (key == NULL) {
     return NULL;

--- a/hash-table/hash_table.h
+++ b/hash-table/hash_table.h
@@ -2,6 +2,7 @@
 #define HASH_TABLE_H
 
 #include "../common.h"
+#include <stdbool.h>
 
 #define HASH_TABLE_SIZE 2000
 
@@ -24,5 +25,7 @@ void delete_c(HashTable *hashTable, const char *key);
 HashTable *createHashTable();
 
 void destroyHashTable(HashTable *hashTable);
+
+bool table_exists(HashTable *hashTable, const char *key);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -152,7 +152,6 @@ int main(void) {
   char *reduced_ast_str = ast_to_string(reduced);
   printf("%s\n", reduced_ast_str);
 
-  free_ast(parsed);
   destroyHashTable(table);
   close_file(in);
   return 1;

--- a/parser.c
+++ b/parser.c
@@ -2,7 +2,11 @@
 #include "common.h"
 #include "hash-table/hash_table.h"
 #include "io.h"
+#include "reducer.h"
 #include <string.h>
+#include <math.h>
+
+static int n = 1;
 
 tokens_t parse_token(char token) {
   if (token == '(') {
@@ -102,9 +106,9 @@ void append_ast_to_buffer(char **buffer, size_t *buffer_size, size_t *length, As
 
     switch (node->type) {
         case LAMBDA_EXPR:
-            append_to_buffer(buffer, buffer_size, length, "(@.");
+            append_to_buffer(buffer, buffer_size, length, "(@");
             append_to_buffer(buffer, buffer_size, length, node->node.lambda_expr->parameter);
-            append_to_buffer(buffer, buffer_size, length, " ");
+            append_to_buffer(buffer, buffer_size, length, ".");
             append_ast_to_buffer(buffer, buffer_size, length, node->node.lambda_expr->body);
             append_to_buffer(buffer, buffer_size, length, ") ");
             break;
@@ -176,6 +180,7 @@ void print_ast(AstNode *node) {
 
 bool is_variable(char token) {
   int cmp = (int)token;
+  if (cmp == '_') return true;
   if (cmp < 97 || cmp > 122) {
     return false;
   }
@@ -218,6 +223,41 @@ AstNode *create_lambda(char *variable, AstNode *body) {
   return lambda;
 }
 
+
+
+// Alpha conversion -> if we have two lambda expressions with same variable
+// name, change one of them to create a new variable: (@x.xx)(@x.x) ->
+// (@x.xx)(@y.y) or -> (@x.xx)(@x'.x')
+
+// Beta reduction: substitution -> we have to look for scope (@x.xy)z => zy
+
+// Eta Conversion / reduction -> Converts between @x.(f x) and f whenever x does
+// not appear free in f which means @x.(f x) = f if f does not make use of x
+// @x.(@y.yy)x) is equivalent to (@y.yy) because f does not make use of x.
+
+// Just convert var to var_n
+char *alpha_convert(char *old) {
+  int digits = (int)log10(abs(n)) + 1;
+
+  char *new = malloc(strlen(old) + digits + 2);
+  HANDLE_NULL(new);
+  char num_str[digits + 1];
+
+  strcpy(new, old);
+
+  sprintf(num_str, "_%d", n);
+  strcat(new, num_str);
+
+  n++;
+
+  return new;
+}
+
+bool is_used(HashTable *table, char *variable) {
+  return table_exists(table, variable);
+}
+
+
 AstNode *parse_lambda(HashTable *table, FILE *in) {
   char parameter = next(in);
   tokens_t param = parse_token(parameter);
@@ -226,13 +266,23 @@ AstNode *parse_lambda(HashTable *table, FILE *in) {
   }
 
   char *var = parse_variable(in, parameter);
+  printf("VAR IS: %s\n", var);
+  char *new_var = NULL;
+  if (is_used(table, var)) {
+    new_var = alpha_convert(var);
+    insert(table, new_var, NULL);
+  } else {
+    insert(table, var, NULL);
+  }
   char dot = next(in);
   if (parse_token(dot) != DOT) {
     expect(".", dot);
   }
-
   AstNode *body = parse_expression(table, in, next(in));
-
+  if (new_var != NULL) {
+    replace(body, var, new_var);
+    return create_lambda(new_var, body);
+  }
   return create_lambda(var, body);
 }
 

--- a/parser.h
+++ b/parser.h
@@ -20,7 +20,6 @@ AstNode *parse_expression(HashTable *table, FILE *in, char token);
 void parse_definition(HashTable *table, FILE *in);
 char *parse_variable(FILE *in, tokens_t token);
 void free_ast(AstNode *node);
-char *ast_to_string(AstNode *node);
 AstNode *create_variable(char *name);
 AstNode *create_application(AstNode *function, AstNode *argument);
 AstNode *create_lambda(char *variable, AstNode *body);

--- a/reducer.c
+++ b/reducer.c
@@ -29,39 +29,12 @@ void print_verbose(const char *format, ...) {
   va_end(args);
 }
 
-bool used_variables[SIZE] = {false};
-
-// Alpha conversion -> if we have two lambda expressions with same variable
-// name, change one of them to create a new variable: (@x.xx)(@x.x) ->
-// (@x.xx)(@y.y) or -> (@x.xx)(@x'.x')
-
-// Beta reduction: substitution -> we have to look for scope (@x.xy)z => zy
-
-// Eta Conversion / reduction -> Converts between @x.(f x) and f whenever x does
-// not appear free in f which means @x.(f x) = f if f does not make use of x
-// @x.(@y.yy)x) is equivalent to (@y.yy) because f does not make use of x.
-
-void set_variable(char variable) { used_variables[(int)variable] = true; }
-
-char new_variable() {
-  for (int i = 0; i < SIZE; i++) {
-    if (!used_variables[i]) {
-      return (char)i;
-    }
-  }
-  printf("No more available variables to do alpha conversion. Quitting");
-  exit(1);
-}
-
-bool is_used(char *variable) { return false; }
-
-
 AstNode *reduce(HashTable *table, AstNode *n) {
   print_verbose("-------------------------------------------\n");
   expand_definitions(table, n);
   print_verbose("Expanded expression:\n");
   print_ast_verbose(n);
-  AstNode *reduced = reduce_ast(n);
+  AstNode *reduced = reduce_ast(table, n);
   print_verbose("Final reduced expression:\n");
   print_ast_verbose(reduced);
   print_verbose("-------------------------------------------\n");
@@ -102,30 +75,18 @@ void replace(AstNode *n, char *old, char *new_name) {
   }
 
   else if (n->type == VAR) {
-    if (strcmp(n->node.variable->name, old)) {
+    if (strcmp(n->node.variable->name, old) == 0) {
       n->node.variable->name = new_name;
     }
   }
 }
 
-AstNode *reduce_ast(AstNode *n) {
+AstNode *reduce_ast(HashTable *table, AstNode *n) {
   if (n->type == LAMBDA_EXPR) {
-    // if a variable is already used and we encounter it on a lambda_expr, we
-    // should rename it and replace it across the body of the lamba expr
-    char *param = n->node.lambda_expr->parameter;
     AstNode *body = n->node.lambda_expr->body;
 
-    if (is_used(param)) {
-      printf("TODO\n");
-      exit(EXIT_FAILURE);
-      // char new = new_variable();
-      // replace(n, n->node.lambda_expr->parameter, new);
-      // set_variable(new);
-    }
-
     // recursively reduce the body
-    n->node.lambda_expr->body = reduce_ast(body);
-
+    n->node.lambda_expr->body = reduce_ast(table, body);
     return n;
   }
 
@@ -134,9 +95,9 @@ AstNode *reduce_ast(AstNode *n) {
     AstNode *function = n->node.application->function;
     AstNode *argument = n->node.application->argument;
 
-    n->node.application->function = reduce_ast(function);
+    n->node.application->function = reduce_ast(table, function);
 
-    n->node.application->argument = reduce_ast(argument);
+    n->node.application->argument = reduce_ast(table, argument);
 
     if (n->node.application->function->type == LAMBDA_EXPR) {
       char *param = n->node.application->function->node.lambda_expr->parameter;

--- a/reducer.c
+++ b/reducer.c
@@ -1,33 +1,7 @@
 #include "reducer.h"
 #include "common.h"
 #include "hash-table/hash_table.h"
-#include "parser.h"
 #include <stdarg.h>
-
-static bool verbose_mode = false;
-
-void set_verbose(bool verbose) {
-  verbose_mode = verbose;
-}
-
-void print_ast_verbose(AstNode *n) {
-  if (verbose_mode == false) {
-    return;
-  }
-  char *lambda_ast = ast_to_string(n);
-  printf("%s\n", lambda_ast);
-}
-
-void print_verbose(const char *format, ...) {
-  if (verbose_mode == false) {
-    return;
-  }
-  printf("\n");
-  va_list args;
-  va_start(args, format);
-  vprintf(format, args);
-  va_end(args);
-}
 
 AstNode *reduce(HashTable *table, AstNode *n) {
   print_verbose("-------------------------------------------\n");

--- a/reducer.h
+++ b/reducer.h
@@ -10,7 +10,7 @@
 #include <string.h>
 
 AstNode *reduce(HashTable *table, AstNode *n);
-AstNode *reduce_ast(AstNode *n);
+AstNode *reduce_ast(HashTable *table, AstNode *n);
 void expand_definitions(HashTable *table, AstNode *n);
 AstNode *deepcopy(AstNode *n);
 AstNode *deepcopy_application(AstNode *function, AstNode *argument);

--- a/reducer.h
+++ b/reducer.h
@@ -19,6 +19,5 @@ AstNode *deepcopy_var(char *name);
 AstNode *substitute(AstNode *expression, char *variable, AstNode *replacement);
 void replace(AstNode *n, char *old, char *new_name);
 void p_print_ast(AstNode *node);
-void set_verbose(bool verbose);
 
 #endif


### PR DESCRIPTION
In general, it is working but some edge cases are not handled yet.

If we have something like: 
```
def a = @x.x

(@a.a)
```
It will identify the name clash on `a` but when it tries to alpha convert, the body of the expression is marked as a definition to be expanded, not a variable, therefore it does not get transformed to a_1.

We are not verbose printing the alpha conversion as well (need refactor on both reduce and parser)

To fix the problem on definitions, i just have to ignore them and consider all as the lambda scope. So i just need to add a case on the replace part.
-----

Actually cant do that because this way the definition would be converted, thats not what i want because it already was inserted and it tries to expand a null. I need to check in the parse step, not the replace step.

Actually thinking this through it may not be a problem, just a constraint. E.g you cant have lambdas with the same name as definitions. Because theres no "correct behavior" for it. If i have:
```
def a = @x.x

@a.a 
``` 
I have three possible behaviors:
- name clash a for a_1
- name clash lambda a for a_1 and leave body as def
- exit because this should not be possible

And im going with the third. Choose your names wisely